### PR TITLE
Add BlockReveal Clarity Smart Contract: Commit-Reveal Scheme on Stacks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/** linguist-vendored
+vitest.config.js linguist-vendored
+* text=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt
+
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# BlockReveal Smart Contract
+
+A Clarity smart contract that implements a commit-reveal scheme on Stacks blockchain. This pattern allows users to commit to a secret value without revealing it immediately, and then reveal it later at a specific block height.
+
+## Features
+
+- Commit a hashed secret with a specified unlock block height
+- Reveal the secret once the unlock block height is reached
+- View revealed secrets and commitment details
+- Built-in validation and error handling
+
+## Usage
+
+### 1. Commit a Secret
+
+First, hash your secret and commit it with an unlock block height:
+
+```clarity
+(contract-call? .blockreveal commit-secret 
+    <hash>  ;; sha256 hash of your secret (buff 32)
+    <unlock-at>  ;; future block height (uint)
+)
+```
+
+### 2. Reveal the Secret
+
+Once the unlock block height is reached, reveal your secret:
+
+```clarity
+(contract-call? .blockreveal reveal-secret
+    <secret>  ;; your original secret (buff 100)
+)
+```
+
+### 3. View a Revealed Secret
+
+Query any revealed secret by principal:
+
+```clarity
+(contract-call? .blockreveal get-secret
+    <user>  ;; principal
+)
+```
+
+### 4. View Commitment Details
+
+Query commitment details by principal:
+
+```clarity
+(contract-call? .blockreveal get-commitment
+    <user>  ;; principal
+)
+```

--- a/contracts/blockreveal.clar
+++ b/contracts/blockreveal.clar
@@ -1,0 +1,61 @@
+(define-map commitments
+  principal ;; Who committed
+  {
+    hash: (buff 32),
+    unlock-block: uint,
+    revealed: bool
+  })
+
+(define-map secrets
+  principal
+  (buff 100))
+
+(define-constant ERR_ALREADY_COMMITTED u100)
+(define-constant ERR_NO_COMMIT u101)
+(define-constant ERR_TOO_EARLY u102)
+(define-constant ERR_HASH_MISMATCH u103)
+(define-constant ERR_ALREADY_REVEALED u104)
+
+;; 1. Commit a secret hash and unlock block
+(define-public (commit-secret (hash (buff 32)) (unlock-at uint))
+  (begin
+    (asserts! (is-none (map-get? commitments tx-sender)) (err ERR_ALREADY_COMMITTED))
+    (map-set commitments tx-sender {
+      hash: hash,
+      unlock-block: unlock-at,
+      revealed: false
+    })
+    (ok true)
+  )
+)
+
+;; 2. Reveal the secret if the block height and hash match
+(define-public (reveal-secret (secret (buff 100)))
+  (let (
+    (commitment (unwrap! (map-get? commitments tx-sender) (err ERR_NO_COMMIT)))
+    (hashed (sha256 secret))
+  )
+    (begin
+      (asserts! (>= burn-block-height (get unlock-block commitment)) (err ERR_TOO_EARLY))
+      (asserts! (is-eq (get hash commitment) hashed) (err ERR_HASH_MISMATCH))
+      (asserts! (not (get revealed commitment)) (err ERR_ALREADY_REVEALED))
+      (map-set secrets tx-sender secret)
+      (map-set commitments tx-sender (merge commitment { revealed: true }))
+      (ok true)
+    )
+  )
+)
+
+;; 3. View someone's revealed secret (if revealed)
+(define-read-only (get-secret (user principal))
+  (map-get? secrets user)
+)
+
+;; 4. View commitment details
+(define-read-only (get-commitment (user principal))
+  (map-get? commitments user)
+)
+
+;; Get the current block height
+(define-read-only (get-block-height)
+  burn-block-height)


### PR DESCRIPTION
Pull Request Description:
This PR introduces the BlockReveal smart contract, written in Clarity, which implements a secure commit-reveal scheme on the Stacks blockchain. The contract allows users to:
Commit a hashed secret with a specified unlock block height
Reveal the original secret after the unlock block height is reached
Query revealed secrets and commitment details for any user
Enforces validation and error handling for common edge cases

